### PR TITLE
Improve documentation of OTF feature files

### DIFF
--- a/fontspec.dtx
+++ b/fontspec.dtx
@@ -1815,7 +1815,8 @@ This work consists of this file fontspec.dtx
 % Adding a new OpenType feature is as creating a plain text file defining
 % the new feature and then loading it by passing its name or path to
 % \feat{FeatureFile}, then OpenType features defined in the file can be
-% activated as usual.
+% activated as usual. Feature files' names should be lower-case, and the
+% conventional extension is \texttt{.fea}.
 %
 % For example, when adding one of the default features like \texttt{kern}
 % or \texttt{liga}, no special activation is needed. On the other hand,


### PR DESCRIPTION
It seems that the correct keyword for character substitution is "subsitute", not "sub". This concurs with the spec at http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#6.b.i and the working example at http://compgroups.net/comp.text.tex/fontspec-+-lualatex-using-a-featurefile/121254

Add a note about naming of feature files. (If I have uppercase letters in a feature file name, it doesn't work.)
