### PR TITLE
Remove redudant variant generation

### DIFF
--- a/fontspec.dtx
+++ b/fontspec.dtx
@@ -2834,7 +2834,6 @@ This work consists of this file fontspec.dtx
 %    \begin{macrocode}
 \cs_generate_variant:Nn \str_if_eq:nnTF {nv}
 \cs_generate_variant:Nn \int_set:Nn {Nv}
-\cs_generate_variant:Nn \tl_gset:Nn {cV}
 \cs_generate_variant:Nn \keys_set:nn {nx}
 \cs_generate_variant:Nn \keys_set_known:nnN {nx}
 %    \end{macrocode}
@@ -4278,8 +4277,6 @@ This work consists of this file fontspec.dtx
 % \begin{macro}{\@@_save_fontinfo:nn}
 % Saves the relevant font information for future processing.
 %    \begin{macrocode}
-\cs_generate_variant:Nn \prop_gput:Nnn {cnV}
-\cs_generate_variant:Nn \prop_gput:Nnn {cnx}
 \cs_new:Nn \@@_save_fontinfo:
  {
   \prop_new:c {g_@@_ \l_fontspec_family_tl _prop}


### PR DESCRIPTION
`\tl_gset:cV` and `\prop_gput:cn(V|x)` have been in expl3 since
2011-04-30 (3d377e140abba03da0b749a9d892e9b7eca8c1f1) and
2011-04-27 (f7ff4f7eaaeb7e9e5e73a891ee5b5d03fab8360a), respectively.

As fontspec does

    \RequirePackage{expl3}[2011/09/05]

the variant generate can be removed and cuts down log noise.