### PR TITLE
Modify to work out of the box with core ltluatex interface as well as the existing luatexbase interface

### DIFF
--- a/fontspec.dtx
+++ b/fontspec.dtx
@@ -2763,7 +2763,7 @@ This work consists of this file fontspec.dtx
   \luatex_if_engine:TF
    {
     \RequirePackage{luaotfload}[2013/05/20]
-    \RequireLuaModule{fontspec}
+    \directlua{require("fontspec")}
    }
    {
     \msg_fatal:nn {fontspec} {cannot-use-pdftex}
@@ -6926,12 +6926,17 @@ local err, warn, info, log = luatexbase.provides_module(fontspec.module)
 %    \end{macrocode}
 % Some utility functions
 %    \begin{macrocode}
-fontspec.log     = log
-fontspec.warning = warn
-fontspec.error   = err
+fontspec.log     = log or (function (s) luatexbase.module_info("fontspec", s) end)
+fontspec.warning = warn or (function (s) luatexbase.module_warning("fontspec", s) end)
+fontspec.error   = err or (function (s) luatexbase.module_error("fontspec", s) end)
 
+if luatexbase.catcodetables == nil then
+  latexpackage_catcodetable=luatexbase.registernumber("catcodetable@atletter")
+else
+  latexpackage_catcodetable=luatexbase.catcodetables['latex-package']
+end
 function fontspec.sprint (...)
-    tex.sprint(luatexbase.catcodetables['latex-package'], ...)
+    tex.sprint(latexpackage_catcodetable, ...)
 end
 %    \end{macrocode}
 %


### PR DESCRIPTION
Hi, the diff here would enable fontspec to work with the proposed latex  kernel `ltuatex` code without requiring the `emu-luatexbase` luatexbase emulation layer. (A similar pull request has been sent to luaotfload)