### PR TITLE
Fix #227: wrong Unicode code point in documentation for visible space

### DIFF
--- a/fontspec-patches.dtx
+++ b/fontspec-patches.dtx
@@ -148,7 +148,7 @@
 % Many thanks to Apostolos Syropoulos for discovering this problem and writing the  redefinion of \LaTeX's |verbatim| environment and \cs{verb*} command.
 %
 % \begin{macro}{\fontspec_visible_space:}
-% Print \unichar{2434}{Open box}, which is used to visibly display a space character.
+% Print \unichar{2423}{Open box}, which is used to visibly display a space character.
 %    \begin{macrocode}
 \cs_new:Nn \fontspec_visible_space:
  {
@@ -160,7 +160,7 @@
 % \end{macro}
 %
 % \begin{macro}{\fontspec_visible_space:@fallback}
-% If the current font doesn't have \unichar{2434}{Open box}, use Latin Modern Mono instead.
+% If the current font doesn't have \unichar{2423}{Open box}, use Latin Modern Mono instead.
 %    \begin{macrocode}
 \cs_new:Nn \fontspec_visible_space_fallback:
  {


### PR DESCRIPTION
Code comments referred to U+2434 where U+2423 was intended.

	modified:   fontspec-patches.dtx