### PR TITLE
Initial Travis-CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+install:
+ - source ./texlive.sh
+
+cache:
+  directories:
+    - /tmp/texlive
+
+script:
+ - texlua build.lua check -H

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -514,9 +514,9 @@ This package redefines \LaTeX's \cmd\-\ macro such that it adjusts along with th
    EXAMPLE HYPHENATION%
  }}\qquad\qquad\null\par\bigskip}
 
- \fontspec{Linux Libertine O}[HyphenChar=None]
+ \fontspec{LinLibertine_R.otf}[HyphenChar=None]
  \text
- \fontspec{Linux Libertine O}[HyphenChar={+}]
+ \fontspec{LinLibertine_R.otf}[HyphenChar={+}]
  \text
 \end{Xexample}
 

--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -14,17 +14,19 @@ fonts.
 }
 
 These are the main font-selecting commands of this package.
-The \cs{fontspec} command selects a font for one-time use; all
+The \cs{fontspec} command selects a font for one-time use only; all
 others should be used to define the standard fonts used in a document, as shown in \exref{fontload}.
 Here, the scales of the fonts have been chosen to equalise their
 lowercase letter heights. The \feat{Scale} font feature will be discussed
 further in \vref{sec:font-ind-features}, including methods for automatic
 scaling.
+Note that further options may need to be added to select appropriate bold/italic fonts,
+but this shows the main idea.
 
 \begin{Lexample}{fontload}{Loading the default, sans serif, and monospaced fonts.}
   \setmainfont{texgyrebonum-regular.otf}
   \setsansfont{lmsans10-regular.otf}[Scale=MatchLowercase]
-  \setmonofont{Inconsolata.otf}[Scale=MatchLowercase]
+  \setmonofont{Inconsolatazi4-Regular.otf}[Scale=MatchLowercase]
 
   \rmfamily Pack my box with five dozen liquor jugs\par
   \sffamily Pack my box with five dozen liquor jugs\par

--- a/fontspec-doc-opentype.tex
+++ b/fontspec-doc-opentype.tex
@@ -280,7 +280,7 @@ will look. OpenType fonts may contain the following options:
    \Huge\centering
    \def\test#1#2{%
      #2 $\to$ {\addfontfeature{#1} #2}\\}
-   \fontspec{Linux Libertine O}
+   \fontspec{LinLibertine_R.otf}
    \test{Ligatures=Historic}{strict}
    \test{Ligatures=Rare}{wurtzite}
    \test{Ligatures=NoCommon}{firefly}
@@ -324,7 +324,7 @@ in \exref{letters-uppercase}; note the raised position of the hyphen
 to better match the surrounding letters.
 
 \begin{Lexample}{letters-uppercase}{An example of the \opt{Uppercase} option of the \feat{Letters} feature.}
-  \fontspec{Linux Libertine O}
+  \fontspec{LinLibertine_R.otf}
    UPPER-CASE example \\
   \addfontfeature{Letters=Uppercase}
    UPPER-CASE example
@@ -775,7 +775,7 @@ to \texttt{Alternate=0} to access the default case.
 
 \begin{Xexample}[firstline=2]{salt}{The \feat{Alternate} feature.}
   \huge
-  \fontspec{Linux Libertine O}
+  \fontspec{LinLibertine_R.otf}
   \textsc{a} \& h \\
   \addfontfeature{Alternate=0}
   \textsc{a} \& h

--- a/fontspec-doc.tex
+++ b/fontspec-doc.tex
@@ -19,7 +19,7 @@
 \title{The \textsf{fontspec} package\\Font selection for \XeLaTeX\ and \LuaLaTeX}
 \author{
    \textsc{Will Robertson} and \textsc{Khaled Hosny}\\
-   \texttt{will.robertson@latex-project.org}
+   \url{http://wspr.io/fontspec/}
 }
 \date{\filedate \qquad \fileversion}
 

--- a/fontspec-fontload.dtx
+++ b/fontspec-fontload.dtx
@@ -1,5 +1,5 @@
 
-% \section{expl3 interface for font loading}
+% \section{expl3 interface for primitive font loading}
 %
 % \iffalse
 %    \begin{macrocode}

--- a/fontspec-opentype.dtx
+++ b/fontspec-opentype.dtx
@@ -119,9 +119,9 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\cs_new:Nn \@@_swap_plus_minus:n { \@@_swap_plus_minus_aux:NNNNN #1 }
-\cs_new:Nn \@@_swap_plus_minus_aux:NNNNN
-  { \str_case:nn {#1} { {+} {-#2#3#4#5} {-} {+#2#3#4#5} } }
+\cs_new:Nn \@@_swap_plus_minus:n { \@@_swap_plus_minus_aux:Nq #1 \q_nil }
+\cs_new:Npn \@@_swap_plus_minus_aux:Nq #1#2 \q_nil
+  { \str_case:nn {#1} { {+} {-#2} {-} {+#2} } }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,0 +1,10 @@
+selected_scheme scheme-infraonly
+TEXDIR /tmp/texlive
+TEXMFCONFIG ~/.texlive/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /tmp/texlive/texmf-local
+TEXMFSYSCONFIG /tmp/texlive/texmf-config
+TEXMFSYSVAR /tmp/texlive/texmf-var
+TEXMFVAR ~/.texlive/texmf-var
+option_doc 0
+option_src 0

--- a/texlive.sh
+++ b/texlive.sh
@@ -30,23 +30,14 @@ tlmgr install cm etex knuth-lib latex-bin tex tex-ini-files unicode-data \
 
 # Dependencies
 tlmgr install  \
-  euenc        \
   geometry     \
   graphics     \
-  graphics-cfg \
-  graphics-def \
   ifluatex     \
   ifxetex      \
-  oberdiek     \
-  l3kernel     \
-  l3packages   \
-  lm           \
-  lualibs      \
   luaotfload   \
-  metafont     \
-  mfware       \
+  oberdiek     \
   tex-gyre     \
-  xunicode
+  unicode-math
 
 # Keep no backups (not required, simply makes cache bigger)
 tlmgr option -- autobackup 0

--- a/texlive.sh
+++ b/texlive.sh
@@ -45,6 +45,7 @@ tlmgr install  \
   luaotfload   \
   metafont     \
   mfware       \
+  tex-gyre     \
   xunicode
 
 # Keep no backups (not required, simply makes cache bigger)

--- a/texlive.sh
+++ b/texlive.sh
@@ -31,6 +31,7 @@ tlmgr install cm etex knuth-lib latex-bin tex tex-ini-files unicode-data \
 # Dependencies
 tlmgr install  \
   euenc        \
+  geometry     \
   graphics     \
   graphics-cfg \
   graphics-def \

--- a/texlive.sh
+++ b/texlive.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+# This script is used for testing using Travis
+# It is intended to work on their VM set up: Ubuntu 12.04 LTS
+# As such, the nature of the system is hard-coded
+# A minimal current TL is installed adding only the packages that are
+# required
+
+# See if there is a cached verson of TL available
+export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+if ! command -v texlua > /dev/null; then
+  # Obtain TeX Live
+  wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+  tar -xzf install-tl-unx.tar.gz
+  cd install-tl-20*
+
+  # Install a minimal system
+  ./install-tl --profile=../texlive.profile
+
+  cd ..
+fi
+
+# l3build itself and LuaTeX: need for texlua
+tlmgr install l3build luatex
+
+# Required to build plain and LaTeX formats:
+# TeX90 plain for unpacking
+tlmgr install cm etex knuth-lib latex-bin tex tex-ini-files unicode-data \
+  xetex
+
+# Dependencies
+tlmgr install  \
+  euenc        \
+  graphics     \
+  graphics-cfg \
+  graphics-def \
+  ifluatex     \
+  ifxetex      \
+  oberdiek     \
+  l3kernel     \
+  l3packages   \
+  lm           \
+  lualibs      \
+  luaotfload   \
+  metafont     \
+  mfware       \
+  xunicode
+
+# Keep no backups (not required, simply makes cache bigger)
+tlmgr option -- autobackup 0
+
+# Update the TL install but add nothing new
+tlmgr update --self --all --no-auto-install


### PR DESCRIPTION
As with the `unicode-math` request, this doesn't give a set of passing outcomes but does allow Travis-CI to run. Some of the test files here seem to need updating, and as with the `unicode-math` case there are some that I think are using non-free fonts. Those cases need adjustment: perhaps a flag could be set (Travis-CI allows environmental variables to be set, which might then be passed with a bit of thought to TeX.)