### PR TITLE
append UprightFont and UprightFeatures to the lists in the document [ci skip]

### DIFF
--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -143,7 +143,8 @@ features requested.
  \feat{BoldItalicFeatures}\texttt=\marg{features} \\
  \feat{SlantedFeatures}\texttt=\marg{features} \\
  \feat{BoldSlantedFeatures}\texttt=\marg{features} \\
- \feat{SmallCapsFeatures}\texttt=\marg{features}
+ \feat{SmallCapsFeatures}\texttt=\marg{features} \\
+ \feat{UprightFeatures}\texttt=\marg{features}
 }
 
 It is entirely possible that separate fonts in a family will require

--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -299,7 +299,8 @@ A legacy \TeX\ font. {\unicodefont A unicode font.}
  \feat{~BoldItalicFont} = \meta{font name} \\
  \feat{SlantedFont} = \meta{font name} \\
  \feat{BoldSlantedFont} = \meta{font name} \\
- \feat{SmallCapsFont} = \meta{font name}
+ \feat{SmallCapsFont} = \meta{font name} \\
+ \feat{UprightFont} = \meta{font name}
 }
 
 The automatic bold, italic, and bold italic font selections will not be


### PR DESCRIPTION
`UprightFont` and `UprightFeatures` appear in the document but do not in the lists at II.2.1 and III.3, resp.