### PR TITLE
doc typo

### DIFF
--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -528,7 +528,7 @@ to be successful. (Actually, it is \emph{only} \pkg{euler} that is the
 problem.\note{Speaking of \pkg{euler}, if you want to use its
 \texttt{[mathbf]} option, it won't work, and you'll need to put this after
 \pkg{fontspec} is loaded instead:
-\ttfamily\cmd\AtBeginDocument\char`\{\cmd\DeclareMathAlphabet\cmd\mathbf\char`\{U\char`\}\char`\{eur\char`\}\char`\{b\char`\}\char`\{n\char`\}})
+\ttfamily\cmd\AtBeginDocument\char`\{\cmd\DeclareMathAlphabet\cmd\mathbf\char`\{U\char`\}\char`\{eur\char`\}\char`\{b\char`\}\char`\{n\char`\}\char`\}})
 
 Note that \pkg{fontspec} will not change the font for general mathematics;
 only the upright and bold shapes will be affected.

--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -35,7 +35,7 @@ These defaults (and further customisations possible) are discussed in \vref{sec:
 \cmdbox{%
   \CMD{\string\newfontfamily}\meta{cmd}\marg{font}\oarg{font features}\\
   \CMD{\string\setfontfamily}{\color[gray]{0.5}\meta{cmd}\marg{font}\oarg{font features}}\\
-  \CMD{\string\renewfontfamily}{\color[gray]{0.5}\meta{cmd}\marg{font}\oarg{font features}}
+  \CMD{\string\renewfontfamily}{\color[gray]{0.5}\meta{cmd}\marg{font}\oarg{font features}}\\
   \CMD{\string\providefontfamily}{\color[gray]{0.5}\meta{cmd}\marg{font}\oarg{font features}}
 }
 
@@ -135,7 +135,7 @@ search paths may be used directly (including in the current directory)
 without having to explicitly define the location of the font file on disk.
 
 Fonts selected by filename must include bold and italic variants explicitly,
-unless a \texttt{.fontspec} file is supplied for the font family (see section~\ref{sec:fontspecfile}).
+unless a \texttt{.fontspec} file is supplied for the font family (see \ref{sec:fontspecfile}).
 We'll give some first examples specifying everything explicitly:
 \begin{Verbatim}
   \setmainfont{texgyrepagella-regular.otf}[
@@ -300,8 +300,8 @@ commands:
   \newcommand\textnote[1]{{\notefont #1}}
   \textnote{This is a note.}
 \end{Verbatim}
-Note that the double braces are intentional; the inner pair are used to
-to delimit the scope of the font change.
+Note that the double braces are intentional; the inner pair is used to
+delimit the scope of the font change.
 
 \begin{Lexample}{nff}{Defining new font families.}
   \newfontfamily\notefont{Kurier}
@@ -431,7 +431,7 @@ In \LaTeX's \NFSS, font families are defined with names such as `\texttt{ppl}' (
   \fontfamily{ppl}\selectfont
 \end{Verbatim}
 In \pkg{fontspec}, the family names are auto-generated based on the fontname of the font; for example, writing |\fontspec{Times New Roman}| for the first time would generate an internal font family name of `\texttt{TimesNewRoman(1)}'.
-Please note that should not rely on the name that is generated.
+Please note that you should not rely on the name that is generated.
 
 In certain cases it is desirable to be able to choose this internal font family name so it can be re-used elsewhere for interacting with other packages that use the \LaTeX's font selection interface; an example might be
 \begin{Verbatim}


### PR DESCRIPTION
## Status
**READY**

## Description

Updated on 2019 Aug 30:

Fix doc (`fontspec.pdf`) typos reported by #378. Detailed change list:
* p.9, second macro box, insert line break just before `\providefontfamily`
* p.11, para.3, "see section Section 2.3" -> "see Section 2.3"
* p.14, para.2 after `\textnote`, "are used to to delimit" -> "is used to delimit"
* p.16, section 4.2, "note that should not" -> "note that you should not"
* p.18, footnote, missing closing brace at end

The first commit is my original commit, which only fixed the last item of change list.
The second commit did the rest.