### PR TITLE
Allow FakeBold with LuaTeX

### DIFF
--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -783,7 +783,6 @@
       },
     FakeStretch .default:n = {1.2}
   }
-%<*XE>
 \keys_define:nn {fontspec}
   {
     FakeBold .code:n =
@@ -792,13 +791,6 @@
       },
     FakeBold .default:n = {1.5}
   }
-%</XE>
-%<*LU>
-\keys_define:nn {fontspec}
-  {
-    FakeBold .code:n = { \@@_warning:n {fakebold-only-xetex} }
-  }
-%</LU>
 %    \end{macrocode}
 % These are to be given to a shape that has no real bold/italic
 % to signal that \pkg{fontspec} should automatically create `fake' shapes.

--- a/fontspec-code-msg.dtx
+++ b/fontspec-code-msg.dtx
@@ -192,11 +192,6 @@
  {
   The "cm-default" package option is obsolete.
  }
-\@@_msg_new:nnn {fontspec} {fakebold-only-xetex}
- {
-  The "FakeBold" and "AutoFakeBold" options are only available with XeLaTeX.\\
-  Option ignored.
- }
 \@@_msg_new:nnn {fontspec} {font-index-needs-ttc}
  {
   The "FontIndex" feature is only supported by TTC (TrueType Collection) fonts.\\

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -585,8 +585,6 @@ are equivalent:
 If both of the \feat{AutoFake...} features are used, then the bold italic
 font will also be faked.
 
-The \feat{FakeBold} and \feat{AutoFakeBold} features are only available with the \XeTeX\ engine and will be ignored in \LuaTeX.
-
 
 \subsection{Letter spacing}
 Letter spacing, or tracking, is the term given to adding (or subtracting) a small amount of horizontal space in between adjacent characters. It is specified with the \feat{LetterSpace}, which takes a numeric argument,


### PR DESCRIPTION
Both harfload and next version of luaotfload are going to support it.

With old version of these package the option will be silently ignored, but that should be a minor issue as the final document will be the same as before.