### PR TITLE
[doc] sync renaming for "Renderer=HarfBuzz"

### DIFF
--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -326,7 +326,7 @@ Features introduced in this section may be used with any font.
 the text.
 You should think of this as the literal glyphs of the font being coloured in a certain way.
 Notably, this mechanism is different to that of the \pkg{color}/\pkg{xcolor}/\pkg{hyperref}/etc.\ packages, and in fact using \pkg{fontspec} commands to set colour will prevent your text from changing colour using those packages at all!
-For example, if you set the colour in a \verb|\setmainfont| command, \verb|\color{...}| and related commands, including hyperlink colouring, will no longer have any effect on text in this font.)
+(For example, if you set the colour in a \verb|\setmainfont| command, \verb|\color{...}| and related commands, including hyperlink colouring, will no longer have any effect on text in this font.)
 Therefore, \pkg{fontspec}'s colour commands are best used to set explicit colours in specific situations, and the \pkg{xcolor} package is recommended for more general colour functionality.
 
 The colour is defined as a triplet of two-digit Hex RGB

--- a/fontspec-doc-luatex.tex
+++ b/fontspec-doc-luatex.tex
@@ -26,7 +26,7 @@ From 2019 the possibility of using the Harfbuzz text shaping engine within \LuaT
 been developed by Khaled Hosny. When running a suitable \LuaTeX\ engine with Harfbuzz support, \pkg{fontspec} provides the following options:
 
 \begin{itemize}
-\item \feat{Renderer} = \opt{Harfbuzz} : use the Harfbuzz engine without an explicit `shaper'.
+\item \feat{Renderer} = \opt{HarfBuzz} : use the Harfbuzz engine without an explicit `shaper' (the old \opt{Harfbuzz} name is kept for compatibility).
 \item \feat{Renderer} = \opt{OpenType} : use the Harfbuzz engine with the OpenType shaper.
 \item \feat{Renderer} = \opt{AAT} : use the Harfbuzz engine with the AAT shaper.
 \item \feat{Renderer} = \opt{Graphite} : use the Harfbuzz engine with the Graphite shaper.


### PR DESCRIPTION
## Status
**READY**

## Description
fontspec v2.7e renamed `Renderer=Harfbuzz` to `Renderer=HarfBuzz`. This pr syncs doc with this change.