### PR TITLE
\@@_declare_shapes_smcaps:nn setup a `slsc -> itsc` substitution

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -815,6 +815,8 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_declare_shapes_smcaps:nn}
+% We set up a smallcaps font if it has been provided. If the current shape
+% is `it', we also set up a `slsc -> itsc` substitution, like in \verb|\@@_declare_shape_slanted:nn|.
 %    \begin{macrocode}
 \cs_new:Nn \@@_declare_shapes_smcaps:nn
   {
@@ -822,6 +824,15 @@
      {
       \@@_DeclareFontShape:xxxxxx {\g_@@_nfss_enc_tl} {\g_@@_nfss_family_tl} {#1}
         { \@@_combo_sc_shape:n {#2} } {\l_@@_nfss_sc_tl} {\l_@@_postadjust_tl}
+      \bool_if:nT
+        {
+            \str_if_eq_p:ee {#2} {\itdefault}  &&
+          !(\str_if_eq_p:ee {\itscdefault} {\slscdefault})
+        }
+        {
+          \@@_DeclareFontShape:xxxxxx {\g_@@_nfss_enc_tl}{\g_@@_nfss_family_tl}{#1}{\slscdefault}
+            {<->ssub*\g_@@_nfss_family_tl/#1/\itscdefault}{\l_@@_postadjust_tl}
+        }
      }
   }
 %    \end{macrocode}


### PR DESCRIPTION
If a slanted font is not provided, fontspec setup automatic `sl -> it`
substitutions in `\@@_declare_shape_slanted:nn`. But if a small caps
font was provided, an `itsc` shape is defined but there is no
corresponding `slsc -> itsc` substitution.

Fix this by adapting the code of `\@@_declare_shape_slanted:nn` into
`\@@_declare_shapes_smcaps:nn`.


## Status

FOR DISCUSSION (but should be ready)

## Todos
- [ ] Tests added to cover new/fixed functionality
      (Did a manual test)
- [ ] Documentation if necessary
      (Added developer documentation)
- [X] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{fontspec}
\setmainfont{Latin Modern Roman}[
  ItalicFeatures  = { SmallCapsFont = {Latin Modern Roman Caps/I} },
]
\begin{document}
\fontshape{slsc}\selectfont Slanted Small Caps.
\end{document}
```