### PR TITLE
Update script names to Unicode 13.0.

### DIFF
--- a/fontspec-code-scripts.dtx
+++ b/fontspec-code-scripts.dtx
@@ -33,6 +33,7 @@
 \newfontscript{Chakma}{cakm}
 \newfontscript{Cham}{cham}
 \newfontscript{Cherokee}{cher}
+\newfontscript{Chorasmian}{chrs}
 \newfontscript{CJK~Ideographic}{hani}
 \newfontscript{Coptic}{copt}
 \newfontscript{Cypriot~Syllabary}{cprt}
@@ -41,10 +42,12 @@
 \newfontscript{CustomDefault}{latn,DFLT}
 \newfontscript{Deseret}{dsrt}
 \newfontscript{Devanagari}{dev2,deva}
+\newfontscript{Dives~Akuru}{diak}
 \newfontscript{Dogra}{dogr}
 \newfontscript{Duployan}{dupl}
 \newfontscript{Egyptian~Hieroglyphs}{egyp}
 \newfontscript{Elbasan}{elba}
+\newfontscript{Elymaic}{elym}
 \newfontscript{Ethiopic}{ethi}
 \newfontscript{Georgian}{geor}
 \newfontscript{Glagolitic}{glag}
@@ -69,6 +72,7 @@
 \newfontscript{Kannada}{knd2,knda}
 \newfontscript{Kayah~Li}{kali}
 \newfontscript{Kharosthi}{khar}
+\newfontscript{Khitan~Small~Script}{kits}
 \newfontscript{Khmer}{khmr}
 \newfontscript{Khojki}{khoj}
 \newfontscript{Khudawadi}{sind}
@@ -103,8 +107,10 @@
 \newfontscript{Myanmar}{mym2,mymr}
 \newfontscript{N'Ko}{nko~}
 \newfontscript{Nabataean}{nbat}
+\newfontscript{Nandinagari}{nand}
 \newfontscript{Newa}{newa}
 \newfontscript{Nushu}{nshu}
+\newfontscript{Nyiakeng~Puachue~Hmong}{hmnp}
 \newfontscript{Odia}{ory2,orya}
 \newfontscript{Ogham}{ogam}
 \newfontscript{Ol~Chiki}{olck}
@@ -156,7 +162,9 @@
 \newfontscript{Tirhuta}{tirh}
 \newfontscript{Ugaritic~Cuneiform}{ugar}
 \newfontscript{Vai}{vai~}
+\newfontscript{Wancho}{wcho}
 \newfontscript{Warang~Citi}{wara}
+\newfontscript{Yezidi}{yezi}
 \newfontscript{Yi}{yi~~}
 \newfontscript{Zanabazar~Square}{zanb}
 %    \end{macrocode}


### PR DESCRIPTION
This is based on tag names used in the HarfBuzz library.

## Status
**READY**

## Todos
- [ ] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [ ] Code follows expl3 style guidelines
