### PR TITLE
Do not rely on load_external_fontoptions side-effects / Fix IgnoreFontspecFile

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -47,7 +47,7 @@
     \keys_set_known:nn {fontspec-preparse-cfg} {#1}
 
     \@@_init_ttc:n {#2}
-    \@@_load_external_fontoptions:Nn \l_fontspec_fontname_tl {#2}
+    \@@_load_external_fontoptions:N \l_fontspec_fontname_tl
 
     \@@_extract_all_features:n {#1}
     \tl_set:Nx \l_@@_fontid_tl { \tl_to_str:N \l_fontspec_fontname_tl-:-\tl_to_str:N \l_@@_all_features_clist }
@@ -138,16 +138,16 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_load_external_fontoptions:Nn}
+% \begin{macro}{\@@_load_external_fontoptions:N}
 % Load a possible \texttt{.fontspec} font configuration file.
 % This file could set font-specific options for the font about to be loaded.
+% The parameter should be a tokenlist containing a sanitised fontname.
 %    \begin{macrocode}
-\cs_new:Nn \@@_load_external_fontoptions:Nn
+\cs_new:Nn \@@_load_external_fontoptions:N
   {
     \bool_if:NT \l_@@_fontcfg_bool
       {
-%<debug>  \typeout{:: @@_load_external_fontoptions:Nn \exp_not:N #1 {#2} }
-        \@@_sanitise_fontname:Nn #1 {#2}
+%<debug>  \typeout{:: @@_load_external_fontoptions:N \exp_not:N #1 }
         \tl_set:Nx \l_@@_ext_filename_tl {#1.fontspec}
         \tl_remove_all:Nn \l_@@_ext_filename_tl {~}
         \prop_if_in:NVF \g_@@_fontopts_prop #1
@@ -677,7 +677,8 @@
 \cs_new:Nn \@@_load_fontname:Nn
   {
 %<debug>    \typeout{:: @@_load_fontname:Nn \exp_not:N #1 (#1) {#2} }
-    \@@_load_external_fontoptions:Nn #1 {#2}
+    \@@_sanitise_fontname:Nn #1 {#2}
+    \@@_load_external_fontoptions:N #1
     \prop_get:NVNF \g_@@_fontopts_prop #1 \l_@@_fontopts_clist
       { \clist_clear:N \l_@@_fontopts_clist }
     \keys_set_groups:nnV {fontspec/fontname} {getfontname} \l_@@_fontopts_clist

--- a/fontspec-code-msg.dtx
+++ b/fontspec-code-msg.dtx
@@ -26,27 +26,27 @@
 %    \begin{macrocode}
 \cs_generate_variant:Nn \msg_new:nnn  {nnx}
 \cs_generate_variant:Nn \msg_new:nnnn {nnxx}
+\cs_new:Nn \@@_msg_new:nn
+  { \msg_new:nnx {fontspec} {#1} { \tl_trim_spaces:n {#2} } }
 \cs_new:Nn \@@_msg_new:nnn
-  { \msg_new:nnx {#1} {#2} { \tl_trim_spaces:n {#3} } }
-\cs_new:Nn \@@_msg_new:nnnn
-  { \msg_new:nnxx {#1} {#2} { \tl_trim_spaces:n {#3} } { \tl_trim_spaces:n {#4} } }
+  { \msg_new:nnxx {fontspec} {#1} { \tl_trim_spaces:n {#2} } { \tl_trim_spaces:n {#3} } }
 \char_set_catcode_space:n {32}
 %    \end{macrocode}
 %
 % \subsection{Errors}
 %
 %    \begin{macrocode}
-\@@_msg_new:nnn {fontspec} {only-inside-encdef}
+\@@_msg_new:nn {only-inside-encdef}
  {
-  \exp_not:N#1can only be used in the second argument
+  \exp_not:N #1 can only be used in the second argument
   to \string\DeclareUnicodeEncoding.
  }
-\@@_msg_new:nnn {fontspec} {no-size-info}
+\@@_msg_new:nn {no-size-info}
  {
   Size information must be supplied.\\
   For example, SizeFeatures={Size={8-12},...}.
  }
-\@@_msg_new:nnnn {fontspec} {font-not-found}
+\@@_msg_new:nnn {font-not-found}
  {
   The font "#1" cannot be found.
  }
@@ -55,18 +55,18 @@
   Check the spelling, where the font is installed etc. etc.\\\\
   When in doubt, ask someone for help!
  }
-\@@_msg_new:nnnn {fontspec} {rename-feature-not-exist}
+\@@_msg_new:nnn {rename-feature-not-exist}
  {
   The feature #1 doesn't appear to be defined.
  }
  {
   It looks like you're trying to rename a feature that doesn't exist.
  }
-\@@_msg_new:nnn {fontspec} {no-glyph}
+\@@_msg_new:nn {no-glyph}
  {
   '#1' does not contain glyph #2.
  }
-\@@_msg_new:nnnn {fontspec} {euler-too-late}
+\@@_msg_new:nnn {euler-too-late}
  {
   The euler package must be loaded BEFORE fontspec.
  }
@@ -76,7 +76,7 @@
   loaded after euler. Type <return> to proceed
   with incorrect \string\mathit, \string\mathbf, etc.
  }
-\@@_msg_new:nnnn {fontspec} {no-xcolor}
+\@@_msg_new:nnn {no-xcolor}
  {
   Cannot load named colours without the xcolor package.
  }
@@ -84,7 +84,7 @@
   Sorry, I can't do anything to help. Instead of loading
   the color package, use xcolor instead.
  }
-\@@_msg_new:nnnn {fontspec} {unknown-color-model}
+\@@_msg_new:nnn {unknown-color-model}
  {
   Error loading colour `#1'; unknown colour model.
  }
@@ -92,7 +92,7 @@
   Sorry, I can't do anything to help. Please report this error
   to my developer with a minimal example that causes the problem.
  }
-\@@_msg_new:nnnn {fontspec} {not-in-addfontfeatures}
+\@@_msg_new:nnn {not-in-addfontfeatures}
  {
   The "#1" font feature cannot be used in \string\addfontfeatures.
  }
@@ -107,17 +107,17 @@
 % \subsection{Warnings}
 %
 %    \begin{macrocode}
-\@@_msg_new:nnn {fontspec} {tu-clash}
+\@@_msg_new:nn {tu-clash}
  {
   I have found the tuenc.def encoding definition file but the TU encoding is not
   defined by the LaTeX2e kernel; attempting to correct but you really should update
   to the latest version of LaTeX2e.
  }
-\@@_msg_new:nnn {fontspec} {tu-missing}
+\@@_msg_new:nn {tu-missing}
  {
   The TU encoding seems to be missing; please update to the latest version of LaTeX2e.
  }
-\@@_msg_new:nnn {fontspec} {addfontfeatures-ignored}
+\@@_msg_new:nn {addfontfeatures-ignored}
  {
   \string\addfontfeature (s) ignored \msg_line_context:;
   it cannot be used with a font that wasn't selected by a fontspec command.\\
@@ -127,77 +127,77 @@
     { The requested feature is "#1". }
     { The requested features are "#1". }
  }
-\@@_msg_new:nnn {fontspec} {feature-option-overwrite}
+\@@_msg_new:nn {feature-option-overwrite}
  {
   Option '#2' of font feature '#1' overwritten.
  }
-\@@_msg_new:nnn {fontspec} {ot-tag-too-long}
+\@@_msg_new:nn {ot-tag-too-long}
  {
   OpenType tag '#1' is too long; script, language, and feature tags must be four characters or fewer.
  }
-\@@_msg_new:nnn {fontspec} {aat-feature-not-exist}
+\@@_msg_new:nn {aat-feature-not-exist}
  {
   '\l_keys_key_tl=\l_keys_value_tl' feature not supported
   for AAT font '\l_fontspec_fontname_tl'.
  }
-\@@_msg_new:nnn {fontspec} {aat-feature-not-exist-in-font}
+\@@_msg_new:nn {aat-feature-not-exist-in-font}
  {
   AAT feature '\l_keys_key_tl=\l_keys_value_tl' (#1) not available
   in font '\l_fontspec_fontname_tl'.
  }
-\@@_msg_new:nnn {fontspec} {icu-feature-not-exist}
+\@@_msg_new:nn {icu-feature-not-exist}
  {
   '\l_keys_key_tl=\l_keys_value_tl' feature not supported
   for OpenType font '\l_fontspec_fontname_tl'
  }
-\@@_msg_new:nnn {fontspec} {icu-feature-not-exist-in-font}
+\@@_msg_new:nn {icu-feature-not-exist-in-font}
  {
   OpenType feature '\l_keys_key_tl=\l_keys_value_tl' (#1) not available
   for font '\l_fontspec_fontname_tl'
   with script '\l_@@_script_name_tl' and language '\l_@@_lang_name_tl'.
  }
-\@@_msg_new:nnn {fontspec} {no-opticals}
+\@@_msg_new:nn {no-opticals}
  {
   '#1' doesn't appear to have an Optical Size axis.
  }
-\@@_msg_new:nnn {fontspec} {language-not-exist}
+\@@_msg_new:nn {language-not-exist}
  {
   Language '#1' not available
   for font '\l_fontspec_fontname_tl'
   with script '\l_@@_script_name_tl'.
  }
-\@@_msg_new:nnn {fontspec} {only-xetex-feature}
+\@@_msg_new:nn {only-xetex-feature}
  {
   Ignored XeTeX-only feature: '#1'.
  }
-\@@_msg_new:nnn {fontspec} {only-luatex-feature}
+\@@_msg_new:nn {only-luatex-feature}
  {
   Ignored LuaTeX-only feature: '#1'.
  }
-\@@_msg_new:nnn {fontspec} {unknown-renderer}
+\@@_msg_new:nn {unknown-renderer}
  {
   Renderer '#1' unknown. Assuming Harfbuzz with 'shaper=#1'.
   Please raise a fontspec issue to add this shaper to the interface.
  }
-\@@_msg_new:nnn {fontspec} {no-mapping}
+\@@_msg_new:nn {no-mapping}
  {
   Input mapping not supported in LuaTeX.
  }
-\@@_msg_new:nnn {fontspec} {no-mapping-ligtex}
+\@@_msg_new:nn {no-mapping-ligtex}
  {
   Input mapping not supported in LuaTeX.\\
   Use "Ligatures=TeX" instead of "Mapping=tex-text".
  }
-\@@_msg_new:nnn {fontspec} {cm-default-obsolete}
+\@@_msg_new:nn {cm-default-obsolete}
  {
   The "cm-default" package option is obsolete.
  }
-\@@_msg_new:nnn {fontspec} {font-index-needs-ttc}
+\@@_msg_new:nn {font-index-needs-ttc}
  {
   The "FontIndex" feature is only supported by TTC (TrueType Collection) fonts.\\
   Feature ignored.
  }
-\@@_msg_new:nnn {fontspec} {feat-cannot-remove}
+\@@_msg_new:nn {feat-cannot-remove}
  {
   The "#1" feature cannot be deactivated. Request ignored.
  }
@@ -206,7 +206,7 @@
 % \subsection{Info messages}
 %
 %    \begin{macrocode}
-\@@_msg_new:nnn {fontspec} {defining-font}
+\@@_msg_new:nn {defining-font}
  {
   Font family '\g_@@_nfss_family_tl' created for font '#2'
   with options [\l_@@_all_features_clist].\\
@@ -214,33 +214,33 @@
   This font family consists of the following NFSS series/shapes:\\
   \g_@@_defined_shapes_tl
  }
-\@@_msg_new:nnn {fontspec} {no-font-shape}
+\@@_msg_new:nn {no-font-shape}
  {
   Could not resolve font "#1" (it probably doesn't exist).
  }
-\@@_msg_new:nnn {fontspec} {set-scale}
+\@@_msg_new:nn {set-scale}
  {
   \l_fontspec_fontname_tl\space scale = \l_@@_scale_tl.
  }
-\@@_msg_new:nnn {fontspec} {setup-math}
+\@@_msg_new:nn {setup-math}
  {
   Adjusting the maths setup (use [no-math] to avoid this).
  }
-\@@_msg_new:nnn {fontspec} {no-script}
+\@@_msg_new:nn {no-script}
  {
   Font "#1" does not contain requested Script "#2".
  }
-\@@_msg_new:nnn {fontspec} {opa-twice}
+\@@_msg_new:nn {opa-twice}
  {
   Opacity set twice, in both Colour and Opacity.\\
   Using specification "Opacity=#1".
  }
-\@@_msg_new:nnn {fontspec} {opa-twice-col}
+\@@_msg_new:nn {opa-twice-col}
  {
   Opacity set twice, in both Opacity and Colour.\\
   Using an opacity specification in hex of "#1/FF".
  }
-\@@_msg_new:nnn {fontspec} {bad-colour}
+\@@_msg_new:nn {bad-colour}
  {
   Bad colour declaration "#1".
   Colour must be one of:\\


### PR DESCRIPTION
## Status
**READY**

## Description
Basically `\@@_load_fontname:Nn` called `\@@_load_external_fontoptions:Nn #1 {#2}` without setting `#1` first and relied on `#1` being set afterwards. This assumption broke when the font was loaded with `IgnoreFontspecFile` which turns `\@@_load_external_fontoptions:Nn #1 {#2}` into a no-op.

This could be fixed by always setting `#1` in `\@@_load_external_fontoptions:Nn`, even if `IgnoreFontspecFile` is used, but I considered it cleaner to do it outside because it's not really related to loading the fontoptions. At that point there is no longer a real need to even pass `#2` to `\@@_load_external_fontoptions:Nn` since it can be read from `#1` anyway, so the function became `\@@_load_external_fontoptions:N`.

(This is the bug causing https://tex.stackexchange.com/questions/556917/lualatex-font-discrepancies-and-compilation-speed-with-fontspec/576788#576788)
## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
The following file printed both "hello"s upright before this fix:
```
\documentclass{article}
\usepackage{fontspec}
\setmainfont{texgyrepagella}[
  IgnoreFontspecFile,
  Extension = .otf ,
  UprightFont = *-regular ,
  ItalicFont  = *-italic  ,
]
\begin{document}
hello \emph{hello}
\end{document}
```

