### PR TITLE
Add 'chws' and 'vchw' feature tags

### DIFF
--- a/fontspec-code-opentype.dtx
+++ b/fontspec-code-opentype.dtx
@@ -356,6 +356,7 @@
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {case}{Case-Sensitive~Forms}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {ccmp}{Glyph~Composition~/~Decomposition}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {cfar}{Conjunct~Form~After~Ro}
+\prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {chws}{Contextual~Half-width~Spacing}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {cjct}{Conjunct~Forms}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {clig}{Contextual~Ligatures}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {cpct}{Centered~CJK~Punctuation}
@@ -456,6 +457,7 @@
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {unic}{Unicase}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {valt}{Alternate~Vertical~Metrics}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {vatu}{Vattu~Variants}
+\prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {vchw}{Vertical~Contextual~Half-width~Spacing}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {vert}{Vertical~Writing}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {vhal}{Alternate~Vertical~Half~Metrics}
 \prop_gput:Nnn \g_@@_all_opentype_feature_names_prop {vjmo}{Vowel~Jamo~Forms}


### PR DESCRIPTION
_OpenType® Specification Version 1.9_ includes two feature tags, 'chws' and 'vchw', but these two tags are missing in the file _fontspec-code-opentype.dtx._ This PR adds them, and the descriptions for these two tags will appear in Table 5 of the file _fontspec.pdf_
