### PR TITLE
Unicode 16.0

### DIFF
--- a/fontspec-code-scripts.dtx
+++ b/fontspec-code-scripts.dtx
@@ -49,6 +49,7 @@
 \newfontscript{Elbasan}{elba}
 \newfontscript{Elymaic}{elym}
 \newfontscript{Ethiopic}{ethi}
+\newfontscript{Garay}{gara}
 \newfontscript{Georgian}{geor}
 \newfontscript{Glagolitic}{glag}
 \newfontscript{Gothic}{goth}
@@ -57,6 +58,7 @@
 \newfontscript{Gujarati}{gjr2,gujr}
 \newfontscript{Gunjala~Gondi}{gong}
 \newfontscript{Gurmukhi}{gur2,guru}
+\newfontscript{Gurung~Khema}{gukh}
 \newfontscript{Hangul~Jamo}{jamo}
 \newfontscript{Hangul}{hang}
 \newfontscript{Hanifi~Rohingya}{rohg}
@@ -77,6 +79,7 @@
 \newfontscript{Khmer}{khmr}
 \newfontscript{Khojki}{khoj}
 \newfontscript{Khudawadi}{sind}
+\newfontscript{Kirat~Rai}{krai}
 \newfontscript{Lao}{lao~}
 \newfontscript{Latin}{latn}
 \newfontscript{Lepcha}{lepc}
@@ -116,6 +119,7 @@
 \newfontscript{Odia}{ory2,orya}
 \newfontscript{Ogham}{ogam}
 \newfontscript{Ol~Chiki}{olck}
+\newfontscript{Ol~Onal}{onao}
 \newfontscript{Old~Italic}{ital}
 \newfontscript{Old~Hungarian}{hung}
 \newfontscript{Old~North~Arabian}{narb}
@@ -146,6 +150,7 @@
 \newfontscript{Sora~Sompeng}{sora}
 \newfontscript{Sumero-Akkadian~Cuneiform}{xsux}
 \newfontscript{Sundanese}{sund}
+\newfontscript{Sunuwar}{sunu}
 \newfontscript{Syloti~Nagri}{sylo}
 \newfontscript{Syriac}{syrc}
 \newfontscript{Tagalog}{tglg}
@@ -164,7 +169,9 @@
 \newfontscript{Tibetan}{tibt}
 \newfontscript{Tifinagh}{tfng}
 \newfontscript{Tirhuta}{tirh}
+\newfontscript{Todhri}{todr}
 \newfontscript{Toto}{toto}
+\newfontscript{Tulu-Tigalari}{tutg}
 \newfontscript{Ugaritic~Cuneiform}{ugar}
 \newfontscript{Vai}{vai~}
 \newfontscript{Vithkuqi}{vith}


### PR DESCRIPTION
Update script names in `fontspec-code-scripts.dtx`.

This is based on tag names used in the beta version of the OpenType specification 1.9.1, which in turn is based on the alpha version of Unicode 16.0 (to be released in Autumn 2024).
