### PR TITLE
Fix missing permissions in Pages workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Documentation
         run: l3build doc -q -H --show-log-on-error
       - name: Copy PDF
-        run: pwd; ls; cp *.pdf ./_site/ 
+        run: sudo cp *.pdf ./_site/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,6 +33,21 @@ jobs:
         with:
           source: ./doc
           destination: ./_site
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v3
+        with:
+          package_file: .github/tl_packages
+      - name: Checkout fonts for testing
+        uses: actions/checkout@v4
+        with:
+          repository: wspr/fontspec-test-fonts
+          path: fontspec-test-fonts
+      - name: Install fonts for testing
+        run: ./fontspec-test-fonts/install.sh
+      - name: Documentation
+        run: l3build doc -q -H --show-log-on-error
+      - name: Copy PDF
+        run: pwd; ls; cp *.pdf ./_site/ 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
## Status
**READY**

## Description

`actions/jekyll-build-pages` is a Docker action hence is run by the default Docker user (root). So we need `sudo` in copying into the directory created by Jekyll. See actions/jekyll-build-pages#101.

https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

Due to branch filtering setting, this PR won't trigger workflow `jekyll-gh-pages.yml`. See a successful testing run https://github.com/muzimuzhi/fontspec/actions/runs/9129444592/job/25104020051, in which the branch filtering rule is relaxed.