### PR TITLE
\__fontspec_check_script:Nn fails in some cases

### DIFF
--- a/fontspec-code-opentype.dtx
+++ b/fontspec-code-opentype.dtx
@@ -246,7 +246,7 @@
         \@@_ot_validate_tag:x {#2}
         \@@_ot_validate_tag:x {#3}
         \cs_if_eq:NNTF #1 \font
-          { \tl_set:Nx \l_@@_tmp_tl {\curr@fontshape/\f@size} }
+          { \tl_set:Nx \l_@@_tmp_tl {\exp_after:wN \cs_to_str:N \the\font} }
           { \tl_set:Nx \l_@@_tmp_tl {\cs_to_str:N #1} }
         \@@_lua_function:neee {check_ot_lang} {\l_@@_tmp_tl} {#2} {#3}
         \bool_if:NTF \l__fontspec_check_bool \prg_return_true: \prg_return_false:

--- a/fontspec-code-opentype.dtx
+++ b/fontspec-code-opentype.dtx
@@ -175,7 +175,7 @@
 %<*LU>
         \@@_ot_validate_tag:x {#2}
         \cs_if_eq:NNTF #1 \font
-          { \tl_set:Nx \l_@@_tmp_tl {\curr@fontshape/\f@size} }
+          { \tl_set:Nx \l_@@_tmp_tl {\exp_after:wN \cs_to_str:N \the\font} }
           { \tl_set:Nx \l_@@_tmp_tl {\cs_to_str:N #1} }
 %<debug>\typeout{::::~ checking:~"\l_@@_tmp_tl",~ "#2"}
         \lua_now:e { fontspec.check_ot_script("\l_@@_tmp_tl", "#2") }

--- a/testfiles/api-script-missing-shape.lvt
+++ b/testfiles/api-script-missing-shape.lvt
@@ -1,15 +1,15 @@
 \input{fontspec-testsetup.tex}
 
 \usepackage{fontspec}
-\setmainfont{DavidCLM-Medium.otf}
+\setmainfont{texgyrepagella-regular.otf}
 
 \begin{document}
 
 \ExplSyntaxOn
 
-\scshape
+\fontshape{foo}\selectfont
 
-\MSG{Does~ the~ David~ font~ has~ the~ 'hebr'~ script?}
-\fontspec_if_script:nTF{hebr}{\MSG{Yes!}}{\ERROR}
+\MSG{Does~ the~ TeX~ Gyre~ Pagella~ font~ has~ the~ 'cyrl'~ script?}
+\fontspec_if_script:nTF{cyrl}{\MSG{Yes!}}{\ERROR}
 
 \end{document}

--- a/testfiles/api-script-missing-shape.lvt
+++ b/testfiles/api-script-missing-shape.lvt
@@ -1,0 +1,15 @@
+\input{fontspec-testsetup.tex}
+
+\usepackage{fontspec}
+\setmainfont{DavidCLM-Medium.otf}
+
+\begin{document}
+
+\ExplSyntaxOn
+
+\scshape
+
+\MSG{Does~ the~ David~ font~ has~ the~ 'hebr'~ script?}
+\fontspec_if_script:nTF{hebr}{\MSG{Yes!}}{\ERROR}
+
+\end{document}

--- a/testfiles/api-script-missing-shape.tlg
+++ b/testfiles/api-script-missing-shape.tlg
@@ -1,0 +1,6 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Does the David font has the 'hebr' script?
+Yes!
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/api-script-missing-shape.tlg
+++ b/testfiles/api-script-missing-shape.tlg
@@ -1,6 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-Does the David font has the 'hebr' script?
+Does the TeX Gyre Pagella font has the 'cyrl' script?
 Yes!
 ***************
 Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
If for some reason \curr@fontshape is not the really the shape of the currently selected font, 
e.g. due to a missing shape, and LuaTeX is the used engine, 
the expansion of '\curr@fontshape/\f@size' is not
the name of the font switch that needs to be checked. Example:

It would be more reliable to use \the\font to get
the name of the switch of the currently selected font.

## Todos
- [x] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{fontspec}
\setmainfont{David CLM}
\begin{document}
\scshape % comment this line to see the effect
\ExplSyntaxOn
\fontspec_if_script:nTF{hebr}{yes}{no}
\end{document}
```
Note how this example returns true with LuaTeX but false with XeTeX.
