### PR TITLE
Run CI on ubuntu-latest

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -21,7 +21,7 @@ jobs:
   # create three jobs which only differ in minimal elements.
   # For tags we do not run this since we run the release job instead.
   l3build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # include indicates that we want to set explicitly these combinations


### PR DESCRIPTION
## Status
**READY**

## Description

Ubuntu 20 image is closing down
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down

The CI would fail at checking `testfiles/polyglossia-add-script.lvt` with
```
! LaTeX Error: The variable \familytype has not been declared on line ....
```
which is a `polyglossia` issue.

`polyglossia` has already fixed it in dev, by first renaming `\familytype` to `\l_xpg_familytype_tl` (https://github.com/reutenauer/polyglossia/commit/2d1cd78aa5bfd99d915a7e1e0ffbb278c196c2a7, https://github.com/reutenauer/polyglossia/commit/3c6e50e985087866e6862cce747a2ff6d9275c53), then adding `\tl_new:N \l_xpg_familytype_tl` (https://github.com/reutenauer/polyglossia/commit/5a0d492d24ac069a02352b494a4a140740d8972f).

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines
